### PR TITLE
Allow root_value to be passed along to GraphQL.execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Allows you to easily mount a GraphQL endpoint in Phoenix.
           query: %GraphQL.ObjectType{
             name: "RootQueryType",
             fields: %{
-              greeting: %GraphQL.FieldDefinition{
+              greeting: %{
                 type: "String",
                 resolve: &TestSchema.greeting/3
               }

--- a/lib/graphql/plug.ex
+++ b/lib/graphql/plug.ex
@@ -16,7 +16,7 @@ defmodule GraphQL.Plug do
       s -> s
     end
     root_value = Keyword.get(opts, :root_value, %{})
-    %{root_value: root_value, schema: schema}
+    %{:schema => schema, :root_value => root_value}
   end
 
   def call(conn, opts) do

--- a/lib/graphql/plug.ex
+++ b/lib/graphql/plug.ex
@@ -15,7 +15,8 @@ defmodule GraphQL.Plug do
       {mod, func} -> apply(mod, func, [])
       s -> s
     end
-    %{schema: schema}
+    root_value = Keyword.get(opts, :root_value, %{})
+    %{root_value: root_value, schema: schema}
   end
 
   def call(conn, opts) do

--- a/lib/graphql/plug/endpoint.ex
+++ b/lib/graphql/plug/endpoint.ex
@@ -10,11 +10,11 @@ defmodule GraphQL.Plug.Endpoint do
       s -> s
     end
     root_value = Keyword.get(opts, :root_value, %{})
-    %{root_value: root_value, schema: schema}
+    %{:schema => schema, :root_value => root_value}
   end
 
   def call(%Conn{method: m} = conn, opts) when m in ["GET", "POST"] do
-    %{root_value: root_value, schema: schema} = conn.assigns[:graphql_options] || opts
+    %{:schema => schema, :root_value => root_value} = conn.assigns[:graphql_options] || opts
 
     query = query(conn)
     evaluated_root_value = evaluate_root_value(conn, root_value)
@@ -51,7 +51,6 @@ defmodule GraphQL.Plug.Endpoint do
   end
 
   defp execute(conn, schema, root_value, query) do
-
     case GraphQL.execute(schema, query, root_value) do
       {:ok, data} ->
         case Poison.encode(%{data: data}) do
@@ -70,8 +69,8 @@ defmodule GraphQL.Plug.Endpoint do
     apply(mod, func, [conn])
   end
 
-  defp evaluate_root_value(conn, root_value) when is_function(root_value, 1) do
-    apply(root_value, [conn])
+  defp evaluate_root_value(conn, fn_root_value) when is_function(fn_root_value, 1) do
+    apply(fn_root_value, [conn])
   end
 
   defp evaluate_root_value(_, nil) do

--- a/lib/graphql/plug/endpoint.ex
+++ b/lib/graphql/plug/endpoint.ex
@@ -70,11 +70,11 @@ defmodule GraphQL.Plug.Endpoint do
     apply(mod, func, [conn])
   end
 
-  defp evaluate_root_value(conn, root_value) when is_function(root_value) do
+  defp evaluate_root_value(conn, root_value) when is_function(root_value, 1) do
     apply(root_value, [conn])
   end
 
-  defp evaluate_root_value(_, root_value) when is_nil(root_value) do
+  defp evaluate_root_value(_, nil) do
     %{}
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "cowlib": {:hex, :cowlib, "1.0.2"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.11.0"},
-  "graphql": {:hex, :graphql, "0.0.9"},
+  "graphql": {:hex, :graphql, "0.1.0"},
   "plug": {:hex, :plug, "1.0.2"},
   "poison": {:hex, :poison, "1.5.0"},
   "ranch": {:hex, :ranch, "1.2.0"}}


### PR DESCRIPTION
During plug initialization, allows a function to be defined that will
take a conn as input and then return a data structure that can be
used as the root_value into the GraphQL.execute method.
