### PR TITLE
Handle content-type: application/graphql

### DIFF
--- a/lib/graphql/plug/endpoint.ex
+++ b/lib/graphql/plug/endpoint.ex
@@ -22,8 +22,8 @@ defmodule GraphQL.Plug.Endpoint do
   def call(%Conn{method: m} = conn, schema) when m in ["GET", "POST"] do
     if graphql?(conn) do
       case read_body(conn) do
-        {:err, reason} -> handle_error(conn, reason)
-        {:ok, query}   ->
+        {:error, reason} -> handle_error(conn, reason)
+        {:ok, query} ->
           conn = Map.put(conn, :params, %{"query" => query})
           call(conn, schema)
       end
@@ -76,5 +76,5 @@ defmodule GraphQL.Plug.Endpoint do
   defp read_body({:more, partial_body, conn}, acc) do
     read_body(Plug.Conn.read_body(conn), acc <> partial_body)
   end
-  defp read_body({:err, reason}, _acc), do: {:err, reason}
+  defp read_body({:error, reason}, _acc), do: {:error, reason}
 end

--- a/lib/graphql/plug/endpoint.ex
+++ b/lib/graphql/plug/endpoint.ex
@@ -1,5 +1,5 @@
 defmodule GraphQL.Plug.Endpoint do
-  import Plug.Conn, except: [read_body: 1, read_body: 2]
+  import Plug.Conn
   alias Plug.Conn
 
   @behaviour Plug
@@ -21,7 +21,7 @@ defmodule GraphQL.Plug.Endpoint do
 
   def call(%Conn{method: m} = conn, schema) when m in ["GET", "POST"] do
     if graphql?(conn) do
-      case read_body(conn) do
+      case read_whole_body(conn) do
         {:error, reason} -> handle_error(conn, reason)
         {:ok, query} ->
           cond do
@@ -70,13 +70,13 @@ defmodule GraphQL.Plug.Endpoint do
     {"content-type", "application/graphql"} in conn.req_headers
   end
 
-  defp read_body(conn) do
-    read_body(Plug.Conn.read_body(conn), "")
+  defp read_whole_body(conn) do
+    read_whole_body(read_body(conn), "")
   end
 
-  defp read_body({:ok, body, _conn}, acc), do: {:ok, acc <> body}
-  defp read_body({:more, partial_body, conn}, acc) do
-    read_body(Plug.Conn.read_body(conn), acc <> partial_body)
+  defp read_whole_body({:ok, body, _conn}, acc), do: {:ok, acc <> body}
+  defp read_whole_body({:more, partial_body, conn}, acc) do
+    read_whole_body(read_body(conn), acc <> partial_body)
   end
-  defp read_body({:error, reason}, _acc), do: {:error, reason}
+  defp read_whole_body({:error, reason}, _acc), do: {:error, reason}
 end

--- a/lib/graphql/plug/endpoint.ex
+++ b/lib/graphql/plug/endpoint.ex
@@ -19,7 +19,7 @@ defmodule GraphQL.Plug.Endpoint do
     end
   end
 
-  def call(%Conn{method: m} = conn, schema) when m in ["GET", "POST"] do
+  def call(%Conn{method: m} = conn, %{schema: schema}) when m in ["GET", "POST"] do
     if graphql?(conn) do
       case read_whole_body(conn) do
         {:error, reason} -> handle_error(conn, reason)

--- a/lib/graphql/plug/endpoint.ex
+++ b/lib/graphql/plug/endpoint.ex
@@ -24,8 +24,10 @@ defmodule GraphQL.Plug.Endpoint do
       case read_body(conn) do
         {:error, reason} -> handle_error(conn, reason)
         {:ok, query} ->
-          conn = Map.put(conn, :params, %{"query" => query})
-          call(conn, schema)
+          cond do
+            String.strip(query) != "" -> handle_call(conn, schema, query)
+            true -> handle_error(conn, "Must provide query body.")
+          end
       end
     else
       handle_error(conn, "Must provide query string.")

--- a/test/graphql/plug/endpoint_test.exs
+++ b/test/graphql/plug/endpoint_test.exs
@@ -87,6 +87,25 @@ defmodule GraphQL.Plug.EndpointTest do
     assert_query {:head,    "/", query: "{greeting}"}, {400, ""}
   end
 
+  test "content-type application/graphql" do
+    success = ~S({"data":{"greeting":"Hello, world!"}})
+    conn = conn(:post, "/", "{greeting}") |> put_req_header("content-type", "application/graphql")
+    assert_response(conn, 200, success)
+  end
+
+  test "content-type application/graphql no body" do
+    empty_body_error = ~S({"errors":[{"message":"Must provide query body."}]})
+
+    conn = conn(:post, "/", nil) |> put_req_header("content-type", "application/graphql")
+    assert_response(conn, 400, empty_body_error)
+
+    conn = conn(:post, "/", "") |> put_req_header("content-type", "application/graphql")
+    assert_response(conn, 400, empty_body_error)
+
+    conn = conn(:post, "/", "  ") |> put_req_header("content-type", "application/graphql")
+    assert_response(conn, 400, empty_body_error)
+  end
+
   # more test inspiration from here
   # https://github.com/graphql/express-graphql/blob/master/src/__tests__/http-test.js
 end


### PR DESCRIPTION
#### What does this PR do?

Handles request which send the `Content-Type: application/graphql` header and the raw request body is the query.
#### How should this be manually tested?
1. Check this branch out
2. Add it as a path dep to a something using plug_graphql and has a schema
3. Send a post request with the `Content-Type: application/graphql` header and the query in the request body.

E.g. (postman, headers tab sets the content-type):

<img width="755" alt="screen shot 2016-01-16 at 12 34 55 pm" src="https://cloud.githubusercontent.com/assets/167362/12369543/a38ac8ea-bc4d-11e5-9416-f5bcd6f672bb.png">
#### Any background context you want to provide?

I tried doing pattern matching with an `in` guard clause:

``` elixir
def call(%Conn{method: m, req_headers: headers} = conn, schema) when {"content-type", "application/graphql"} in headers do
    case read_body(conn) do
      {:err, reason} -> handle_error(conn, reason)
      {:ok, query}   ->
        conn = Map.put(conn, :params, %{"query" => query})
        call(conn, schema)
      end
  end
```

But you get this error:

```
== Compilation error on file lib/graphql/plug/endpoint.ex ==
** (ArgumentError) invalid args for operator in, it expects a compile time list or range on the right side when used in guard expressions, got: headers
```

So this works, but it may be time to rethink how the pattern matching works here a little bit.
