### PR TITLE
GraphiQL support

### DIFF
--- a/lib/graphql/plug.ex
+++ b/lib/graphql/plug.ex
@@ -1,0 +1,25 @@
+defmodule GraphQL.Plug do
+  use Plug.Builder
+
+  plug Plug.Parsers,
+    parsers: [:graphql, :urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Poison
+
+  plug GraphQL.Plug.Endpoint
+  # plug GraphQL.Plug.GraphiQL
+
+  # TODO remove duplication call GraphQL.Plug.Helper.extract_init_options/1 here
+  def init(opts) do
+    schema = case Keyword.get(opts, :schema) do
+      {mod, func} -> apply(mod, func, [])
+      s -> s
+    end
+    %{schema: schema}
+  end
+
+  def call(conn, opts) do
+    conn = assign(conn, :graphql_options, opts)
+    super(conn, opts)
+  end
+end

--- a/lib/plug/parsers/graphql.ex
+++ b/lib/plug/parsers/graphql.ex
@@ -1,0 +1,24 @@
+defmodule Plug.Parsers.GRAPHQL do
+  @moduledoc """
+  Parses a GraphQL request body.
+
+  An empty request body is parsed as an empty map.
+  """
+
+  @behaviour Plug.Parsers
+  import Plug.Conn
+
+  def parse(conn, "application", "graphql", _headers, opts) do
+    conn
+    |> read_body(opts)
+    |> decode
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts) do
+    {:next, conn}
+  end
+
+  defp decode({:more, _, conn}),  do: {:error, :too_large, conn}
+  defp decode({:ok, "", conn}),   do: {:ok, %{}, conn}
+  defp decode({:ok, body, conn}), do: {:ok, %{"query" => body}, conn}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule PlugGraphql.Mixfile do
+defmodule GraphQL.Plug.Mixfile do
   use Mix.Project
 
   @version "0.0.7"

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule GraphQL.Plug.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :plug, :cowboy]]
+    [applications: [:logger, :plug, :cowboy, :graphql]]
   end
 
   defp deps do
@@ -28,7 +28,7 @@ defmodule GraphQL.Plug.Mixfile do
      {:cowboy, "~> 1.0"},
      {:plug, "~> 0.14 or ~> 1.0"},
      {:poison, "~> 1.5"},
-     {:graphql, "~> 0.0.9"}]
+     {:graphql, "~> 0.1.0"}]
   end
 
   defp package do

--- a/test/graphql/plug/endpoint_test.exs
+++ b/test/graphql/plug/endpoint_test.exs
@@ -1,17 +1,17 @@
 defmodule GraphQL.Plug.EndpointTest do
   use ExUnit.Case, async: true
   use Plug.Test
+  import ExUnit.TestHelpers
 
-  # Simplest possible TestSchema
   defmodule TestSchema do
     def schema do
       %GraphQL.Schema{
-        query: %GraphQL.ObjectType{
+        query: %GraphQL.Type.ObjectType{
           name: "Greeting",
           fields: %{
             greeting: %{
               type: "String",
-              resolve: &TestSchema.greeting/3,
+              resolve: {TestSchema, :greeting},
             }
           }
         }
@@ -25,25 +25,13 @@ defmodule GraphQL.Plug.EndpointTest do
   defmodule TestPlug do
     use Plug.Builder
 
-    plug GraphQL.Plug.Endpoint, schema: TestSchema.schema
-  end
-
-  def assert_query({method, path, params}, {status, body}) do
-    assert_response conn(method, path, params), status, body
-  end
-
-  def assert_response(conn, status, body) do
-    conn = TestPlug.call conn, []
-
-    assert conn.status == status
-    assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
-    assert conn.resp_body == body
+    plug GraphQL.Plug, schema: {TestSchema, :schema}
   end
 
   test "GET and POST successful query" do
     success = ~S({"data":{"greeting":"Hello, world!"}})
-    assert_query {:get,  "/", query: "{greeting}"}, {200, success}
-    assert_query {:post, "/", query: "{greeting}"}, {200, success}
+    assert_query TestPlug, {:get,  "/", query: "{greeting}"}, {200, success}
+    assert_query TestPlug, {:post, "/", query: "{greeting}"}, {200, success}
   end
 
   test "specify schema using {module, fun} syntax" do
@@ -52,58 +40,35 @@ defmodule GraphQL.Plug.EndpointTest do
 
       plug GraphQL.Plug.Endpoint, schema: {TestSchema, :schema}
     end
-    conn = conn(:get, "/", query: "{greeting}")
-    conn = TestMFPlug.call conn, []
-
-    assert conn.status == 200
-    assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
-    assert conn.resp_body == ~S({"data":{"greeting":"Hello, world!"}})
+    success = ~S({"data":{"greeting":"Hello, world!"}})
+    assert_query TestMFPlug, {:get,  "/", query: "{greeting}"}, {200, success}
   end
 
   test "missing query" do
     no_query_found_error = ~S({"errors":[{"message":"Must provide query string."}]})
-    assert_query {:get,  "/", nil},         {400, no_query_found_error}
-    assert_query {:get,  "/", query: nil},  {400, no_query_found_error}
-    assert_query {:get,  "/", query: ""},   {400, no_query_found_error}
-    assert_query {:get,  "/", query: "  "}, {400, no_query_found_error}
-    assert_query {:post, "/", nil},         {400, no_query_found_error}
-    assert_query {:post, "/", query: nil},  {400, no_query_found_error}
-    assert_query {:post, "/", query: ""},   {400, no_query_found_error}
-    assert_query {:post, "/", query: "  "}, {400, no_query_found_error}
+    assert_query TestPlug, {:get,  "/", nil},         {400, no_query_found_error}
+    assert_query TestPlug, {:get,  "/", query: nil},  {400, no_query_found_error}
+    assert_query TestPlug, {:get,  "/", query: ""},   {400, no_query_found_error}
+    assert_query TestPlug, {:get,  "/", query: "  "}, {400, no_query_found_error}
+    assert_query TestPlug, {:post, "/", nil},         {400, no_query_found_error}
+    assert_query TestPlug, {:post, "/", query: nil},  {400, no_query_found_error}
+    assert_query TestPlug, {:post, "/", query: ""},   {400, no_query_found_error}
+    assert_query TestPlug, {:post, "/", query: "  "}, {400, no_query_found_error}
   end
 
   test "invalid query error" do
     syntax_error = ~S({"errors":[{"message":"GraphQL: syntax error before:  on line 1","line_number":1}]})
-    assert_query {:get,  "/", query: "{"}, {400, syntax_error}
-    assert_query {:post, "/", query: "{"}, {400, syntax_error}
+    assert_query TestPlug, {:get,  "/", query: "{"}, {400, syntax_error}
+    assert_query TestPlug, {:post, "/", query: "{"}, {400, syntax_error}
   end
 
   test "invalid http verbs" do
     invalid_verb_error = ~S({"errors":[{"message":"GraphQL only supports GET and POST requests."}]})
-    assert_query {:put,     "/", query: "{greeting}"}, {400, invalid_verb_error}
-    assert_query {:patch,   "/", query: "{greeting}"}, {400, invalid_verb_error}
-    assert_query {:delete,  "/", query: "{greeting}"}, {400, invalid_verb_error}
-    assert_query {:options, "/", query: "{greeting}"}, {400, invalid_verb_error}
-    assert_query {:head,    "/", query: "{greeting}"}, {400, ""}
-  end
-
-  test "content-type application/graphql" do
-    success = ~S({"data":{"greeting":"Hello, world!"}})
-    conn = conn(:post, "/", "{greeting}") |> put_req_header("content-type", "application/graphql")
-    assert_response(conn, 200, success)
-  end
-
-  test "content-type application/graphql no body" do
-    empty_body_error = ~S({"errors":[{"message":"Must provide query body."}]})
-
-    conn = conn(:post, "/", nil) |> put_req_header("content-type", "application/graphql")
-    assert_response(conn, 400, empty_body_error)
-
-    conn = conn(:post, "/", "") |> put_req_header("content-type", "application/graphql")
-    assert_response(conn, 400, empty_body_error)
-
-    conn = conn(:post, "/", "  ") |> put_req_header("content-type", "application/graphql")
-    assert_response(conn, 400, empty_body_error)
+    assert_query TestPlug, {:put,     "/", query: "{greeting}"}, {400, invalid_verb_error}
+    assert_query TestPlug, {:patch,   "/", query: "{greeting}"}, {400, invalid_verb_error}
+    assert_query TestPlug, {:delete,  "/", query: "{greeting}"}, {400, invalid_verb_error}
+    assert_query TestPlug, {:options, "/", query: "{greeting}"}, {400, invalid_verb_error}
+    assert_query TestPlug, {:head,    "/", query: "{greeting}"}, {400, ""}
   end
 
   # more test inspiration from here

--- a/test/graphql/plug_test.exs
+++ b/test/graphql/plug_test.exs
@@ -1,0 +1,69 @@
+defmodule GraphQL.PlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+  import ExUnit.TestHelpers
+
+  defmodule TestSchema do
+    def schema do
+      %GraphQL.Schema{
+        query: %GraphQL.Type.ObjectType{
+          name: "Greeting",
+          fields: %{
+            greeting: %{
+              type: "String",
+              resolve: {TestSchema, :greeting},
+            }
+          }
+        }
+      }
+    end
+
+    def greeting(_, %{name: name}, _), do: "Hello, #{name}!"
+    def greeting(_, _, _), do: greeting(%{}, %{name: "world"}, %{})
+  end
+
+  defmodule TestPlug do
+    use Plug.Builder
+
+    plug GraphQL.Plug, schema: {TestSchema, :schema}
+  end
+
+  test "content-type application/graphql" do
+    success = ~S({"data":{"greeting":"Hello, world!"}})
+    conn = conn(:post, "/", "{greeting}") |> put_req_header("content-type", "application/graphql")
+    assert_response(TestPlug, conn, 200, success)
+  end
+
+  test "content-type application/graphql no body" do
+    empty_body_error = ~S({"errors":[{"message":"Must provide query string."}]})
+
+    conn = conn(:post, "/", nil) |> put_req_header("content-type", "application/graphql")
+    assert_response(TestPlug, conn, 400, empty_body_error)
+
+    conn = conn(:post, "/", "") |> put_req_header("content-type", "application/graphql")
+    assert_response(TestPlug, conn, 400, empty_body_error)
+
+    conn = conn(:post, "/", "  ") |> put_req_header("content-type", "application/graphql")
+    assert_response(TestPlug, conn, 400, empty_body_error)
+  end
+
+  test "content-type application/json" do
+    success = ~S({"data":{"greeting":"Hello, world!"}})
+    {:ok, json_body} = Poison.encode(%{query: "{greeting}"})
+    conn = conn(:post, "/", json_body) |> put_req_header("content-type", "application/json")
+    assert_response(TestPlug, conn, 200, success)
+  end
+
+  test "content-type application/json no body" do
+    empty_body_error = ~S({"errors":[{"message":"Must provide query string."}]})
+
+    conn = conn(:post, "/", nil) |> put_req_header("content-type", "application/json")
+    assert_response(TestPlug, conn, 400, empty_body_error)
+
+    conn = conn(:post, "/", "") |> put_req_header("content-type", "application/json")
+    assert_response(TestPlug, conn, 400, empty_body_error)
+
+    # conn = conn(:post, "/", "  ") |> put_req_header("content-type", "application/json")
+    # assert_response(TestPlug, conn, 400, empty_body_error)
+  end
+end

--- a/test/plug/parsers/graphql_test.exs
+++ b/test/plug/parsers/graphql_test.exs
@@ -1,0 +1,30 @@
+defmodule Plug.Parsers.GRAPHQLTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  def graphql_conn(body, content_type \\ "application/graphql") do
+    conn(:post, "/", body) |> put_req_header("content-type", content_type)
+  end
+
+  def parse(conn, opts \\ []) do
+    opts = Keyword.put_new(opts, :parsers, [:graphql])
+    Plug.Parsers.call(conn, Plug.Parsers.init(opts))
+  end
+
+  test "parses the request body" do
+    conn = graphql_conn("{hello}") |> parse()
+    assert conn.params["query"] == "{hello}"
+  end
+
+  test "handles empty body as blank map" do
+    conn = graphql_conn(nil) |> parse()
+    assert conn.params == %{}
+  end
+
+  test "raises on too large bodies" do
+    exception = assert_raise Plug.Parsers.RequestTooLargeError, fn ->
+      graphql_conn("{hello}") |> parse(length: 5)
+    end
+    assert Plug.Exception.status(exception) == 413
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,18 @@
-ExUnit.start()
+ExUnit.start(exclude: [])
+
+defmodule ExUnit.TestHelpers do
+  import ExUnit.Assertions
+  use Plug.Test
+
+  def assert_query(plug, {method, path, params}, {status, body}) do
+    assert_response plug, conn(method, path, params), status, body
+  end
+
+  def assert_response(plug, conn, status, body) do
+    conn = plug.call conn, []
+
+    assert conn.status == status
+    assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+    assert conn.resp_body == body
+  end
+end


### PR DESCRIPTION
- Expose a higher level plug made out of simpler plugs
- Implement custom GraphQL plug parser
- Support all content types

Still some polish and refactoring needed
- GraphiQL handling should occur in it’s own plug
- Remove duplication
