### PR TITLE
Fix example by adding name argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ This [Plug](https://github.com/elixir-lang/plug) allows you to easily mount a Gr
             fields: %{
               greeting: %{
                 type: %GraphQL.Type.String{},
+                args: %{
+                  name: %{
+                    type: %GraphQL.Type.String{}
+                  }
+                },
                 resolve: {TestSchema, :greeting}
               }
             }


### PR DESCRIPTION
fixes issue #19 so that the query with a name param works
