### PR TITLE
Merge conn[:graphql_options] with opts so that :graphql_options set in other plugs make it to GraphQL context.

### DIFF
--- a/lib/graphql/plug/endpoint.ex
+++ b/lib/graphql/plug/endpoint.ex
@@ -55,7 +55,10 @@ defmodule GraphQL.Plug.Endpoint do
   end
 
   def call(%Conn{method: m} = conn, opts) when m in ["GET", "POST"] do
-    %{schema: schema, root_value: root_value} = conn.assigns[:graphql_options] || opts
+    if conn.assigns[:graphql_options] do
+      opts = Map.merge(opts, conn.assigns[:graphql_options])
+    end
+    %{schema: schema, root_value: root_value} = opts
 
     query = query(conn)
     variables = variables(conn)


### PR DESCRIPTION
One example of what this allows us to do is set the logged in user in
:root_value and have it available in resolve functions so we can do
authorization.

See https://github.com/graphql-elixir/graphql-elixir/wiki/How-to-do-authentication-and-authorization-in-a-Phoenix-application-with-GraphQL for example.
