### PR TITLE
Changes to the GraphQL.Plug call function

### DIFF
--- a/lib/graphql/plug.ex
+++ b/lib/graphql/plug.ex
@@ -47,20 +47,20 @@ defmodule GraphQL.Plug do
 
   def call(conn, opts) do
     conn = super(conn, opts)
+    interactive? = GraphiQL.use_graphiql?(conn, opts)
+    case interactive? do
+      true ->
+        conn |> GraphiQL.call(opts)
+        # TODO consider not logging instrospection queries
+        Logger.debug """
+        Processed GraphQL query:
 
-    conn = if GraphiQL.use_graphiql?(conn, opts) do
-      GraphiQL.call(conn, opts)
-    else
-      Endpoint.call(conn, opts)
+        #{conn.params["query"]}
+        """
+      false ->
+        conn |> Endpoint.call(opts)
     end
-
-    # TODO consider not logging instrospection queries
-    Logger.debug """
-    Processed GraphQL query:
-
-    #{conn.params["query"]}
-    """
-
+    
     conn
   end
 end


### PR DESCRIPTION
In experimenting with this plug, I found that there were some unexpected errors hitting the connection on each request.
This is an attempt to remove those errors by eliminating the conn assignment and the IF statement and replacing it with a more direct assignment of just the allow_graphiql? parameter and converting the IF to a CASE statement.

Take a look and let me know what you think.

Also, if you prefer to do this with a different style, feel free to take the basic idea and redo it.

No worries.

JB

The following is the output from a single connection req/res cycle.

```
[info] Sent 200 in 40ms
[debug] Processed GraphQL query:

{greeting}

[error] #PID<0.827.0> running CoherentApi.Endpoint terminated
Server: localhost:4000 (http)
Request: GET /r1/gql?query=%7Bgreeting%7D
** (exit) an exception was raised:
    ** (Plug.Conn.AlreadySentError) the response was already sent
        (plug) lib/plug/conn.ex:888: Plug.Conn.register_before_send/2
        (coherent_api) lib/coherent_api/endpoint.ex:1: CoherentApi.Endpoint.phoenix_pipeline/1
        (coherent_api) lib/plug/debugger.ex:93: CoherentApi.Endpoint."call (overridable 3)"/2
        (coherent_api) lib/phoenix/endpoint/render_errors.ex:34: CoherentApi.Endpoint.call/2
        (phoenix) lib/phoenix/router/route.ex:157: Phoenix.Router.Route.forward/4
        (coherent_api) lib/phoenix/router.ex:261: CoherentApi.Router.dispatch/2
        (coherent_api) web/router.ex:1: CoherentApi.Router.do_call/2
        (coherent_api) lib/coherent_api/endpoint.ex:1: CoherentApi.Endpoint.phoenix_pipeline/1
        (coherent_api) lib/plug/debugger.ex:93: CoherentApi.Endpoint."call (overridable 3)"/2
        (coherent_api) lib/phoenix/endpoint/render_errors.ex:34: CoherentApi.Endpoint.call/2
        (plug) lib/plug/adapters/cowboy/handler.ex:15: Plug.Adapters.Cowboy.Handler.upgrade/4
        (cowboy) src/cowboy_protocol.erl:442: :cowboy_protocol.execute/4
```

Here is the same request after the fixes.

```
[info] GET /r1/gql
[debug] Processing by CoherentApi.PageController.index/2
  Parameters: %{"query" => "{greeting}"}
  Pipelines: [:browser]
[info] Sent 200 in 10ms
```
