### PR TITLE
Mixfile: Updated poison version to support 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule GraphQL.Plug.Mixfile do
 
      {:cowboy, "~> 1.0"},
      {:plug, "~> 0.14 or ~> 1.0"},
-     {:poison, "~> 1.5 or ~> 2.0"},
+     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
      {:graphql, "~> 0.3"}]
   end
 


### PR DESCRIPTION
- Following a brief chat with @aweiker in the #erlang graphql slack channel, it was suggested that adding an or condition would make the graphql plug compatible with newer versions of poison without conflicting with existing phoenix versions.
- The maximum version in the mixfile was updated but the lockfile was left deliberately unchanged.
