### PR TITLE
Append `graphql` to the fetcher URL in template

### DIFF
--- a/templates/graphiql.eex
+++ b/templates/graphiql.eex
@@ -91,7 +91,7 @@ add "&raw" to the end of the URL within a browser.
       function graphQLFetcher(graphQLParams) {
         // NOTE: This fetch URL should be relative to the current URL
         // This is so that the GraphQL Elixir Plug can be mounted anywhere
-        return fetch(window.location.origin + window.location.pathname, {
+        return fetch(window.location.origin + window.location.pathname + 'graphql', {
           method: 'post',
           headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
[This PR](https://github.com/graphql/graphiql/pull/146) changed the fetcher URL to be relative - due to my carelessness this broke GraphiQL example code. I'd like to propose the change that will let you keep the relativeness of the fetcher URL and still have a specific endpoint URL for graphql execution-related requests.