### PR TITLE
Allow poison 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule GraphQL.Plug.Mixfile do
 
      {:cowboy, "~> 1.0"},
      {:plug, "~> 0.14 or ~> 1.0"},
-     {:poison, "~> 1.5 or ~> 2.0"},
+     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
      {:graphql, "~> 0.3"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.3.13", "90d2d2deb9d376bb2a63f81126a320c3920ce65acb1294982ab49a8aacc7d89f", [:mix], [{:bunt, "~> 0.1.4", [hex: :bunt, optional: false]}]},
   "dogma": {:hex, :dogma, "0.1.5", "d8d9c9d50f099c5bde47334da077b555b2027147d16906ea7bb4e7cdaedb2d8b", [:mix], [{:poison, ">= 1.0.0", [hex: :poison, optional: false]}]},


### PR DESCRIPTION
Poison 3.0.0's notable changes are:

* A different license.
* Enforcing of key validation (each key should be unique).

Diff: https://github.com/devinus/poison/compare/2.2.0...3.0.0

Those changes shouldn't impact the plug graphql library.